### PR TITLE
tab shortcut cause coc.vim switched to custom pop

### DIFF
--- a/init.vim
+++ b/init.vim
@@ -64,4 +64,7 @@ let g:airline_symbols.branch = ''
 let g:airline_symbols.readonly = ''
 let g:airline_symbols.linenr = ''
 
-inoremap <expr> <Tab> pumvisible() ? coc#_select_confirm() : "<Tab>"
+inoremap <silent><expr> <TAB>
+    \ coc#pum#visible() ? coc#pum#next(1):
+    \ <SID>check_back_space() ? "\<Tab>" :
+    \ coc#refresh()


### PR DESCRIPTION
coc.vim switched to custom popup menu - gave a msg on startup - resolved via: https://github.com/neoclide/coc.nvim/pull/3862
Beware: Vim Newbie here - not 100% safe that this is the same thing - please carefully consider.